### PR TITLE
Accepts GitLab's embedded Git non-standard version suffix

### DIFF
--- a/lib/Git/Version/Compare.pm
+++ b/lib/Git/Version/Compare.pm
@@ -62,7 +62,7 @@ sub looks_like_git {
     return scalar $_[0] =~
         /^(?:v|git\ version\ )?                               # prefix
           [0-9]+(?:[.-](?:0[ab]?|[1-9][0-9a-z]*|[a-zA-Z]+))*  # x.y.z.*
-          (?:[.-]?rc[0-9]+)?                                  # rc
+          (?:[.-]?[a-z]+[0-9]+)?                              # rc or vendor specific suffixes
           (?:[.-](GIT|[1-9][0-9]*[.-]g[A-Fa-f0-9]+))?         # devel
           (?:\ .*)?                                           # comment
          $/x;
@@ -208,6 +208,10 @@ A Git-aware version of the C<cmp> operator.
 Given a string, returns true if it looks like a Git version number
 (and can therefore be parsed by C<Git::Version::Number>) and false
 otherwise.
+
+It accepts the version strings from all standard Git versions and from some
+non-standard Gits as well, such as GitLab's embedded Git which uses a special
+suffix like C<.gl1>.
 
 =head1 EXPORT TAGS
 

--- a/t/looks_like_git.t
+++ b/t/looks_like_git.t
@@ -33,6 +33,10 @@ my @ok = (
     '0.99.9h', '1.0.rc1', '0.99.9i', '1.0.rc2', '0.99.9j', '1.0.rc3',
     '0.99.9k', '0.99.9l', '1.0.rc4', '0.99.9m', '1.0.rc5', '0.99.9n',
     '1.0.rc6', '1.0.0a',  '1.0.0b',
+
+    # vendor specific versions
+    # GitLab embedded git
+    '2.37.1.gl1',
 );
 
 # non-git version


### PR DESCRIPTION
The GitLab server [0] comes with an "embedded git" binary which is used by its Git server hooks. It's version string uses a non-standard suffix like "2.37.1.gl1". In order to accept this and potentially other Git server vendors the looks_like_git function is being relaxed so that it accepts any sequence of one or more alphabetic characters in place of the standard "rc" (for release candidates) suffix.

Ref0: https://gitlab.com/rluna-gitlab/gitlab-ce